### PR TITLE
add fallback RPC_NODE_URL value

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,7 +3,9 @@ import { PublicKey } from "@solana/web3.js";
 import dotenv from "dotenv";
 dotenv.config();
 
-export const RPC_NODE_URL = process.env.RPC_NODE_URL as string;
+export const RPC_NODE_URL = String(
+  process.env.RPC_NODE_URL || "https://api.mainnet-beta.solana.com"
+);
 
 export const USDC_MINT = new PublicKey(
   "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"


### PR DESCRIPTION
This adds a default fallback RPC URL so that when new users run `yarn start help` for the first time their console doesn't throw

```
TypeError: Endpoint URL must start with `http:` or `https:`.
```

Another option might be to add an additional step in the README explaining that it's required in the `.env`

I wasn't sure which would be the preferred approach here so I'm just opening this PR as a suggestion