### PR TITLE
add `npx jupiter-cli` support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,19 @@ What the CLI is trained to do:
 - Convert spill or fee tokens back to desired mint
 - Provide the level of hygiene of a wallet
 
-## To start
+## Usage
 
-1. You first need to install all the dependencies with `yarn`.
-2. Locate or [setup your file system wallet](https://docs.solana.com/wallet-guide/file-system-wallet#:~:text=A%20file%20system%20wallet%20exists,system%20wallet%20is%20not%20recommended.) file
-3. Run `yarn start help` to see all the commands. You can also run `yarn start help command` to see what each command is for.
+Locate or [setup your file system wallet](https://docs.solana.com/wallet-guide/file-system-wallet#:~:text=A%20file%20system%20wallet%20exists,system%20wallet%20is%20not%20recommended.) file.
 
-## Example
+Run `npx jupiter-cli help` to see all the commands. You can also run `npx . help command` to see what each command is for.
 
-`yarn start swap-tokens --keypair wallet.json`
+### Example
+
+`npx jupiter-cli swap-tokens --keypair wallet.json`
+
+## Running locally
+
+1. Clone the repository
+2. Install all the dependencies with `yarn`
+3. Ensure you have a file system wallet as described above
+4. Run `npx . help` to see all the commands. You will need to run `yarn build` after making any changes to the code, before running `npx .` again.

--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
   "name": "jupiter-cli",
   "version": "1.0.0",
-  "main": "index.js",
+  "bin": "dist/index.js",
   "scripts": {
-    "start": "tsc && node dist/index.js"
+    "postinstall": "yarn build",
+    "build": "tsc"
   },
   "author": "Jupiter",
   "license": "MIT",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import { Connection, PublicKey } from "@solana/web3.js";
 import { Command } from "commander";
 import { RPC_NODE_URL } from "./constants";


### PR DESCRIPTION
This would mean that people can run `npx jupiter-cli` without needing to download and build this repository

Some caveats -

- this would require publishing the package to npm
- `jupiter-cli` [has already been claimed on npm](https://npm.im/jupiter-cli) so the package would need a different name 😢 
- not sure how this would affect the dotenv setup, it might require providing an RPC url in as an argument rather than via env

Feel free to discard this PR, I figured it would be just as quick as opening an issue!