### PR TITLE
add <number> to tokens-from-top option

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ program
   .command("create-token-accounts")
   .requiredOption("-k, --keypair <keypair>")
   .option(
-    "-t, --tokens-from-top",
+    "-t, --tokens-from-top <number>",
     "Tokens from the top to create an account for",
     "10"
   )


### PR DESCRIPTION
currently, running `yarn start create-token-accounts --tokens-from-top 15 --keypair wallet.json` would set `tokensFromTop` to `true`, this change ensures it's parsed as a number and sets it to `15`